### PR TITLE
Added Discord to MC Attachments, Placeholders, and Mentions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Configuration is stored in `config.json` file.
   - `minecraftBroadcastTemplate`: template for messages in Minecraft from `/discord broadcast` command
   - `prefixBlacklist`: a list of prefix string (e.g. `["!"]`) that will be ignored by the plugin _(thanks, Vankka)_
   - `ignoreBots`: ignore all messages from any Discord Bots _(thanks, Vankka)_
+  - `linkDiscordAttachments`: adds a clickable link in game for attachments sent via discord _(thanks, Mohron)_
   - `channels`: a list of channel configurations
 - Channel config
   - `discordId`: the ID of the Discord channel (usually a 18-digit number)
@@ -81,6 +82,18 @@ Configuration is stored in `config.json` file.
     - `broadcastTemplate`: (optional) template for messages in Discord from `/discord broadcast` command
   - `minecraft`: templates in Minecraft
     - `chatTemplate`: (optional) template for messages from Discord to Minecraft
+        - **Supported Placeholders**
+        - %s - the message sent via discord
+        - %a - the username of the message author
+        - %r - the name of the highest role held by the message author (See also defaultRole & roleBlacklist)
+        - %c - the color code of the highest role if set to a Minecraft compatible color
+        - %g - the current game of the message author
+        - %s - the message sent from discord
+    - `attachmentTemplate`: (required for linkDiscordAttachments) template for Discord attachments linked in Minecraft _(thanks, Mohron)_
+    - `attachmentColor`: (optional) designate a color to be applied to attachmentTemplate (ie `&0` or `§0`) _(thanks, Mohron)_
+    - `attachmentHoverTemplate`: (optional) template for the message shown when you hover over an attachment link _(thanks, Mohron)_
+    - `defaultRole`: (optional) a default role and formatting to be used when a user's has no non-blacklisted roles _(thanks, Mohron)_
+    - `roleBlacklist`: (optional) a list of roles to ignore when calculating a user's highest rank _(thanks, Mohron)_
 
 You can find some example configurations in `examples` folders.
 
@@ -98,14 +111,13 @@ You can find some example configurations in `examples` folders.
 ## TODO
 
 * 2.3.0
-- [ ] Mentions in Discord should show proper names in Minecraft
-- [ ] Attachments in Discord should show proper links in Minecraft
+- [X] Mentions in Discord should show proper names in Minecraft
+- [X] Attachments in Discord should show proper links in Minecraft
 
 * Future
 - [ ] MySQL token store
 - [ ] Group-based prefix
 - [ ] Handle custom Sponge channels (e.g. MCClan and staff chat of Nucleus)
-- [ ] Image upload in Discord should show links in Minecraft
 - [ ] A command to check Bot connection status
 - [ ] New config to allow executing Minecraft command from Discord
 - [ ] New config to route Minecraft server log to Discord

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Configuration is stored in `config.json` file.
         - **Supported Placeholders**
         - %s - the message sent via discord
         - %a - the username of the message author
+        - %n - the nickname of the message author or username if not set
         - %r - the name of the highest role held by the message author (See also defaultRole & roleBlacklist)
         - %c - the color code of the highest role if set to a Minecraft compatible color
         - %g - the current game of the message author

--- a/examples/config-multiple.json
+++ b/examples/config-multiple.json
@@ -1,6 +1,7 @@
 {
   "tokenStore": "JSON",
   "botToken": "APP_BOT_USER_TOKEN",
+  "linkDiscordAttachments": true,
   "botDiscordGame": "Minecraft",
   "prefixBlacklist": ["!"],
   "ignoreBots": false,
@@ -17,7 +18,12 @@
         "broadcastTemplate": "_<BROADCAST> %s_"
       },
       "minecraft": {
-        "chatTemplate": "&7<%a> &f%s"
+        "chatTemplate": "&7<%a> &f%s",
+        "attachmentTemplate": "[Attachment]",
+        "attachmentHoverTemplate": "Click to open attachment.",
+        "attachmentColor": "&3",
+        "defaultRole": "&eMember",
+        "roleBlacklist": ["Bot"]
       }
     },
     {

--- a/examples/config-simple.json
+++ b/examples/config-simple.json
@@ -1,6 +1,7 @@
 {
   "tokenStore": "JSON",
   "botToken": "APP_BOT_USER_TOKEN",
+  "linkDiscordAttachments": true,
   "botDiscordGame": "Minecraft",
   "prefixBlacklist": ["!"],
   "ignoreBots": true,
@@ -21,7 +22,12 @@
         "broadcastTemplate": "_<BROADCAST> %s_"
       },
       "minecraft": {
-        "chatTemplate": "&7<%a> &f%s"
+        "chatTemplate": "&7<%a> &f%s",
+        "attachmentTemplate": "[Attachment]",
+        "attachmentHoverTemplate": "Click to open attachment.",
+        "attachmentColor": "&3",
+        "defaultRole": "&eMember",
+        "roleBlacklist": ["Bot"]
       }
     }
   ]

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'Sponge-Discord'
+rootProject.name = 'DiscordBridge'
 

--- a/src/main/java/com/nguyenquyhy/discordbridge/commands/BroadcastCommand.java
+++ b/src/main/java/com/nguyenquyhy/discordbridge/commands/BroadcastCommand.java
@@ -1,7 +1,6 @@
 package com.nguyenquyhy.discordbridge.commands;
 
 import com.nguyenquyhy.discordbridge.DiscordBridge;
-import com.nguyenquyhy.discordbridge.logics.MessageHandler;
 import com.nguyenquyhy.discordbridge.models.GlobalConfig;
 import com.nguyenquyhy.discordbridge.utils.ChannelUtil;
 import com.nguyenquyhy.discordbridge.utils.ErrorMessages;

--- a/src/main/java/com/nguyenquyhy/discordbridge/logics/MessageHandler.java
+++ b/src/main/java/com/nguyenquyhy/discordbridge/logics/MessageHandler.java
@@ -4,12 +4,15 @@ import com.nguyenquyhy.discordbridge.DiscordBridge;
 import com.nguyenquyhy.discordbridge.models.ChannelConfig;
 import com.nguyenquyhy.discordbridge.models.GlobalConfig;
 import com.nguyenquyhy.discordbridge.utils.ChannelUtil;
+import com.nguyenquyhy.discordbridge.utils.ColorUtil;
 import com.nguyenquyhy.discordbridge.utils.TextUtil;
 import de.btobastian.javacord.entities.message.Message;
+import de.btobastian.javacord.entities.message.MessageAttachment;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
 
 /**
  * Created by Hy on 8/6/2016.
@@ -25,11 +28,10 @@ public class MessageHandler {
         Logger logger = mod.getLogger();
         GlobalConfig config = mod.getConfig();
 
-        String content = TextUtil.formatDiscordMessage(message.getContent());
         for (ChannelConfig channelConfig : config.channels) {
             if (config.prefixBlacklist != null) {
                 for (String prefix : config.prefixBlacklist) {
-                    if (StringUtils.isNotBlank(prefix) && content.startsWith(prefix)) {
+                    if (StringUtils.isNotBlank(prefix) && message.getContent().startsWith(prefix)) {
                         return;
                     }
                 }
@@ -40,13 +42,25 @@ public class MessageHandler {
             if (message.getNonce() != null && message.getNonce().equals(ChannelUtil.SPECIAL_CHAR)) {
                 return;
             }
-
             if (StringUtils.isNotBlank(channelConfig.discordId)
                     && channelConfig.minecraft != null
                     && StringUtils.isNotBlank(channelConfig.minecraft.chatTemplate)
                     && message.getChannelReceiver().getId().equals(channelConfig.discordId)) {
-                String author = message.getAuthor().getName();
-                Text formattedMessage = TextUtil.formatUrl(String.format(channelConfig.minecraft.chatTemplate.replace("%a", author), content));
+                Text messageText = TextUtil.formatUrl(TextUtil.formatForMinecraft(channelConfig, message));
+                if (config.linkDiscordAttachments
+                        && StringUtils.isNotBlank(channelConfig.minecraft.attachmentTemplate)
+                        && message.getAttachments() != null) {
+                    for (MessageAttachment attachment:message.getAttachments()) {
+                        String spacing = message.getContent().equals("") ?  "" : " ";
+                        messageText = Text.join(messageText,
+                                Text.builder(spacing + channelConfig.minecraft.attachmentTemplate)
+                                .color(ColorUtil.getTextColor(channelConfig.minecraft.attachmentColor))
+                                .onClick(TextActions.openUrl(attachment.getUrl()))
+                                .onHover(TextActions.showText(Text.of(channelConfig.minecraft.attachmentHoverTemplate)))
+                                .build());
+                    }
+                }
+                Text formattedMessage = messageText;
                 // This case is used for default account
                 logger.info(formattedMessage.toPlain());
                 Sponge.getServer().getOnlinePlayers().forEach(p -> p.sendMessage(formattedMessage));

--- a/src/main/java/com/nguyenquyhy/discordbridge/logics/MessageHandler.java
+++ b/src/main/java/com/nguyenquyhy/discordbridge/logics/MessageHandler.java
@@ -45,6 +45,7 @@ public class MessageHandler {
             if (StringUtils.isNotBlank(channelConfig.discordId)
                     && channelConfig.minecraft != null
                     && StringUtils.isNotBlank(channelConfig.minecraft.chatTemplate)
+                    && message.getChannelReceiver() != null
                     && message.getChannelReceiver().getId().equals(channelConfig.discordId)) {
                 Text messageText = TextUtil.formatUrl(TextUtil.formatForMinecraft(channelConfig, message));
                 if (config.linkDiscordAttachments

--- a/src/main/java/com/nguyenquyhy/discordbridge/models/ChannelMinecraftConfig.java
+++ b/src/main/java/com/nguyenquyhy/discordbridge/models/ChannelMinecraftConfig.java
@@ -3,6 +3,9 @@ package com.nguyenquyhy.discordbridge.models;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Created by Hy on 10/13/2016.
  */
@@ -10,8 +13,23 @@ import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 public class ChannelMinecraftConfig {
     void initializeDefault() {
         chatTemplate = "&7<%a> &f%s";
+        attachmentTemplate = "[Attachment]";
+        attachmentColor = "&3";
+        attachmentHoverTemplate = "Click to open attachment.";
+        defaultRole = "Member";
+        roleBlacklist = new ArrayList<>();
     }
 
     @Setting
     public String chatTemplate;
+    @Setting
+    public String attachmentTemplate;
+    @Setting
+    public String attachmentColor;
+    @Setting
+    public String attachmentHoverTemplate;
+    @Setting
+    public String defaultRole;
+    @Setting
+    public List<String> roleBlacklist;
 }

--- a/src/main/java/com/nguyenquyhy/discordbridge/models/GlobalConfig.java
+++ b/src/main/java/com/nguyenquyhy/discordbridge/models/GlobalConfig.java
@@ -17,6 +17,7 @@ public class GlobalConfig {
         prefixBlacklist = new ArrayList<>();
         ignoreBots = false;
         botDiscordGame = "";
+        linkDiscordAttachments = true;
         minecraftBroadcastTemplate = "&2<BROADCAST> %s";
         botToken = "";
     }
@@ -29,6 +30,8 @@ public class GlobalConfig {
     public List<String> prefixBlacklist;
     @Setting
     public Boolean ignoreBots;
+    @Setting
+    public Boolean linkDiscordAttachments;
     @Setting
     public String botDiscordGame;
     @Setting

--- a/src/main/java/com/nguyenquyhy/discordbridge/utils/ColorUtil.java
+++ b/src/main/java/com/nguyenquyhy/discordbridge/utils/ColorUtil.java
@@ -1,0 +1,89 @@
+package com.nguyenquyhy.discordbridge.utils;
+
+import org.spongepowered.api.text.format.TextColor;
+import org.spongepowered.api.text.format.TextColors;
+
+import java.awt.*;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ColorUtil {
+    private static Map<Color, String> minecraftColors = new HashMap<>();
+
+    static {
+        minecraftColors.put(new Color(0,0,0), "&0");
+        minecraftColors.put(new Color(0,0,170), "&1");
+        minecraftColors.put(new Color(0,170,0), "&2");
+        minecraftColors.put(new Color(0,170,170), "&3");
+        minecraftColors.put(new Color(170,0,0), "&4");
+        minecraftColors.put(new Color(170,0,170), "&5");
+        minecraftColors.put(new Color(255,170,0), "&6");
+        minecraftColors.put(new Color(170,170,170), "&7");
+        minecraftColors.put(new Color(85,85,85), "&8");
+        minecraftColors.put(new Color(85,85,255), "&9");
+        minecraftColors.put(new Color(85,255,85), "&a");
+        minecraftColors.put(new Color(85,255,255), "&b");
+        minecraftColors.put(new Color(255,85,85), "&c");
+        minecraftColors.put(new Color(255,85,255), "&d");
+        minecraftColors.put(new Color(255,255,85), "&e");
+        minecraftColors.put(new Color(255,255,255), "&f");
+    }
+
+    public static String getColorCode(Color color) {
+            return minecraftColors.containsKey(color) ? minecraftColors.get(color) : "";
+    }
+
+    public static TextColor getTextColor(String s) {
+        switch (s.toUpperCase()){
+            case "§0":
+            case "&0":
+                return TextColors.BLACK;
+            case "§1":
+            case "&1":
+                return TextColors.DARK_BLUE;
+            case "§2":
+            case "&2":
+                return TextColors.DARK_GREEN;
+            case "§3":
+            case "&3":
+                return TextColors.DARK_AQUA;
+            case "§4":
+            case "&4":
+                return TextColors.DARK_RED;
+            case "§5":
+            case "&5":
+                return TextColors.DARK_PURPLE;
+            case "§6":
+            case "&6":
+                return TextColors.GOLD;
+            case "§7":
+            case "&7":
+                return TextColors.GRAY;
+            case "§8":
+            case "&8":
+                return TextColors.DARK_GRAY;
+            case "§9":
+            case "&9":
+                return TextColors.BLUE;
+            case "§A":
+            case "&A":
+                return TextColors.GREEN;
+            case "§B":
+            case "&B":
+                return TextColors.AQUA;
+            case "§C":
+            case "&C":
+                return TextColors.RED;
+            case "§D":
+            case "&D":
+                return TextColors.LIGHT_PURPLE;
+            case "§E":
+            case "&E":
+                return TextColors.YELLOW;
+            case "§F":
+            case "&F":
+                return TextColors.WHITE;
+            default: return TextColors.RESET;
+        }
+    }
+}

--- a/src/main/java/com/nguyenquyhy/discordbridge/utils/TextUtil.java
+++ b/src/main/java/com/nguyenquyhy/discordbridge/utils/TextUtil.java
@@ -64,11 +64,13 @@ public class TextUtil {
     }
 
     public static String formatForMinecraft(ChannelConfig config, Message message) {
+        String serverID = message.getChannelReceiver().getServer().getId();
         // Replace %a with Message author's Name
         String s = config.minecraft.chatTemplate.replace("%a", message.getAuthor().getName());
 
-        // Replace %n with Message author's Nickname (Not yet supported)
-        //s = s.replace("%n", message.getAuthor().getNickname());
+        // Replace %n with Message author's Nickname
+        String nickname = (message.getAuthor().getNickname(serverID) != null) ? message.getAuthor().getNickname(serverID) : message.getAuthor().getName();
+        s = s.replace("%n", nickname);
 
         // Get author's highest role
         int position = 0;
@@ -94,7 +96,8 @@ public class TextUtil {
         // Replace Mentions with readable names
         for (User mention: message.getMentions()) {
             s = s.replace("<@"+mention.getId()+">","@" + mention.getName());
-            s = s.replace("<@!"+mention.getId()+">","@" + mention.getName()); // Change to getNickname() when supported
+            String nick = (mention.getNickname(serverID) != null) ? mention.getNickname(serverID) : mention.getName();
+            s = s.replace("<@!"+mention.getId()+">","@" + nick);
         }
 
         return TextUtil.formatDiscordMessage(s);


### PR DESCRIPTION
I guess I deleted my old PR when I was trying to sort out my branches. 

This PR includes some minor improvement on the attachment code as well as includes the support for additional placeholders in the `minecraft` template and readable mentions. I cannot find anyway to retrieve nicknames with Javacord so those are still not supported through mentions or placeholders.

@nguyenquyhy The attachment handling has to be made part of the `formatUrl` or a similar method to still support the hover and link properties as I can't set those with Vanilla formatting and just allow your method to handle the conversion to `Text` as I have done with everything else in this commit.

[Old PR](https://github.com/nguyenquyhy/Sponge-Discord/pull/22)

[Javacord Issue](https://github.com/BtoBastian/Javacord/issues/32)